### PR TITLE
iFactr-Data zip extract

### DIFF
--- a/iFactr.Data/NetworkResource/ResourceStrategy/Cache/CacheZip.cs
+++ b/iFactr.Data/NetworkResource/ResourceStrategy/Cache/CacheZip.cs
@@ -288,7 +288,7 @@ namespace iFactr.Data.Utilities.NetworkResource.ResourceStrategy.Cache
             using (var zip = new System.IO.Compression.ZipArchive(zipBytes, System.IO.Compression.ZipArchiveMode.Read))
                 foreach (var entry in zip.Entries)
                     using (var stream = entry.Open())
-                        Device.File.Save(cachePath.AppendPath(entry.FullName), stream);
+                        Device.File.Save(cachePath.AppendPath(entry.FullName), stream, EncryptionMode.NoEncryption);
 #endif
 
             Device.Log.Metric(string.Format("Extract zip file: file: {0} cache path: {1}  Time: {2:0} milliseconds", zipFileName, cachePath, DateTime.UtcNow.Subtract(dtMetric).TotalMilliseconds));


### PR DESCRIPTION
When using encryption, the expectation is that the zip request from the server contains already encrypted files. The extract needs to save them without adding more encryption. The original working code had been the entry.Extract, but that section is now surrounded with the #if NETCF and the new  Devcie.File.Save code had been put it.